### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/txt/musimetrics-arXiv/musimetrics.bbl
+++ b/txt/musimetrics-arXiv/musimetrics.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/txt/musimetrics/musimetrics.bbl
+++ b/txt/musimetrics/musimetrics.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/txt/musimetrics_old/musimetrics.bbl
+++ b/txt/musimetrics_old/musimetrics.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/txt/phi+mus/musimetrics.bbl
+++ b/txt/phi+mus/musimetrics.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/txt/phi+mus/phi+mus.bbl
+++ b/txt/phi+mus/phi+mus.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/txt/philosometrics/phi4.bbl
+++ b/txt/philosometrics/phi4.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/txt/philosometrics_old/phi4.bbl
+++ b/txt/philosometrics_old/phi4.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all code that generates new DOI links.

Cheers!